### PR TITLE
Added PendingRequestsProjection

### DIFF
--- a/UrbanSpork.API/Startup.cs
+++ b/UrbanSpork.API/Startup.cs
@@ -90,6 +90,7 @@ namespace UrbanSpork.API
             // Projections
             builder.RegisterType<UserDetailProjection>().AsSelf().InstancePerLifetimeScope();
             builder.RegisterType<PermissionDetailProjection>().AsSelf().InstancePerLifetimeScope();
+            builder.RegisterType<PendingRequestsProjection>().AsSelf().InstancePerLifetimeScope();
 
 
             //Commands

--- a/UrbanSpork.DataAccess/DataAccess/UrbanDbContext.cs
+++ b/UrbanSpork.DataAccess/DataAccess/UrbanDbContext.cs
@@ -12,15 +12,18 @@ namespace UrbanSpork.DataAccess.DataAccess
 
         }
 
-        public DbSet<UserDetailProjection> UserDetailProjection {get; set;}
         public DbSet<EventStoreDataRow> Events { get; set; }
 
+        public DbSet<UserDetailProjection> UserDetailProjection { get; set; }
         public DbSet<PermissionDetailProjection> PermissionDetailProjection { get; set; }
+        public DbSet<PendingRequestsProjection> PendingRequestsProjection { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<EventStoreDataRow>()
                 .HasKey(a => new { a.Id, a.Version });
+            modelBuilder.Entity<PendingRequestsProjection>()
+                .HasKey(a => new {a.PermissionId, a.ForId, a.RequestType});
         }
     }
 }

--- a/UrbanSpork.DataAccess/Events/Users/UserPermissionsRequestedEvent.cs
+++ b/UrbanSpork.DataAccess/Events/Users/UserPermissionsRequestedEvent.cs
@@ -23,7 +23,7 @@ namespace UrbanSpork.DataAccess.Events.Users
             {
                 var r = new PermissionRequest
                 {
-                    EventType = JsonConvert.SerializeObject(GetType()),
+                    EventType = JsonConvert.SerializeObject(GetType().FullName),
                     IsPending = true,
                     ReasonForRequest = dto.Requests[request.Key].ReasonForRequest,
                     RequestDate = TimeStamp,

--- a/UrbanSpork.DataAccess/GenericEventPublisher.cs
+++ b/UrbanSpork.DataAccess/GenericEventPublisher.cs
@@ -13,11 +13,15 @@ namespace UrbanSpork.DataAccess
         //list of projection tables
         private readonly UserDetailProjection _userDetailProjection;
         private readonly PermissionDetailProjection _permissionDetailProjection;
+        private readonly PendingRequestsProjection _pendingRequestsProjection;
 
-        public GenericEventPublisher(UserDetailProjection userDetailProjection, PermissionDetailProjection permissionDetailProjection)
+        public GenericEventPublisher(UserDetailProjection userDetailProjection, 
+            PermissionDetailProjection permissionDetailProjection,
+            PendingRequestsProjection pendingRequestsProjection)
         {
             _userDetailProjection = userDetailProjection;
             _permissionDetailProjection = permissionDetailProjection;
+            _pendingRequestsProjection = pendingRequestsProjection;
         }
 
         async Task IEventPublisher.Publish<T>(T @event, CancellationToken cancellationToken)
@@ -25,6 +29,7 @@ namespace UrbanSpork.DataAccess
             //throw all events to each projection
             await _userDetailProjection.ListenForEvents(@event);
             await _permissionDetailProjection.ListenForEvents(@event);
+            await _pendingRequestsProjection.ListenForEvents(@event);
         }
     }
 }

--- a/UrbanSpork.DataAccess/Projections/PendingRequestsProjection.cs
+++ b/UrbanSpork.DataAccess/Projections/PendingRequestsProjection.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UrbanSpork.CQRS.Events;
+using UrbanSpork.DataAccess.DataAccess;
+using UrbanSpork.DataAccess.Events.Users;
+
+namespace UrbanSpork.DataAccess.Projections
+{
+    public class PendingRequestsProjection : IProjection
+    {
+        public readonly UrbanDbContext _context;
+
+        public PendingRequestsProjection() { }
+
+        public PendingRequestsProjection(UrbanDbContext context)
+        {
+            _context = context;
+        }
+
+        public Guid PermissionId { get; set; }
+        public Guid ForId { get; set; }
+        public Guid ById { get; set; }
+        public string RequestType { get; set; }
+
+        [Column(TypeName = "timestamp")]
+        public DateTime DateOfRequest { get; set; }
+
+        public async Task ListenForEvents(IEvent @event)
+        {
+            switch (@event)
+            {
+                case UserPermissionsRequestedEvent upr:
+                    foreach (var r in upr.Requests)
+                    {
+                        var row = new PendingRequestsProjection
+                        {
+                            PermissionId = r.Key,
+                            ForId = r.Value.RequestedFor,
+                            ById = r.Value.RequestedBy,
+                            RequestType = r.Value.EventType,
+                            DateOfRequest = r.Value.RequestDate
+                        };
+
+                        //if a request of that type does not already exist for that user and permission add it to the list
+                        if (!_context.PendingRequestsProjection.Any(a =>
+                            a.PermissionId == row.PermissionId && a.ForId == row.ForId && a.RequestType == row.RequestType))
+                        {
+                            await _context.PendingRequestsProjection.AddAsync(row);
+                        }
+                    }
+                    break;
+            }
+
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/UrbanSpork.DataAccess/Projections/PermissionDetailProjection.cs
+++ b/UrbanSpork.DataAccess/Projections/PermissionDetailProjection.cs
@@ -42,7 +42,7 @@ namespace UrbanSpork.DataAccess.Projections
                     perm.IsActive = pc.IsActive;
                     perm.DateCreated = pc.TimeStamp;
 
-                    _context.PermissionDetailProjection.Add(perm);
+                    await _context.PermissionDetailProjection.AddAsync(perm);
                     break;
             }
             


### PR DESCRIPTION
able to populate and update the pending requests, does not provide a history on how many times the permission was requested, but if the request of for a permission for a user already exists, it will not add it to the list or update. Critical to being able to show which ones have been pending for the longest amount of time.