### PR TITLE
Fixed disabling a permission to have different functionality

### DIFF
--- a/UrbanSpork.DataAccess/Events/Users/UserPermissionRevokedEvent.cs
+++ b/UrbanSpork.DataAccess/Events/Users/UserPermissionRevokedEvent.cs
@@ -29,7 +29,7 @@ namespace UrbanSpork.DataAccess.Events.Users
                 {
                     EventType = JsonConvert.SerializeObject(GetType().FullName),
                     IsPending = false,
-                    Reason = "Revoked", //IDK?
+                    Reason = permission.Value.Reason, //IDK?
                     RequestDate = TimeStamp,
                     RequestedBy = dto.ById,
                     RequestedFor = dto.ForId

--- a/UrbanSpork.DataAccess/PermissionManager.cs
+++ b/UrbanSpork.DataAccess/PermissionManager.cs
@@ -1,20 +1,27 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using AutoMapper;
+using Newtonsoft.Json;
+using UrbanSpork.Common;
 using UrbanSpork.Common.DataTransferObjects.Permission;
+using UrbanSpork.Common.DataTransferObjects.User;
 using UrbanSpork.CQRS.Domain;
+using UrbanSpork.DataAccess.DataAccess;
 
 namespace UrbanSpork.DataAccess
 {
     public class PermissionManager : IPermissionManager
     {
         private readonly ISession _session;
+        private readonly UrbanDbContext _context;
 
-        public PermissionManager(ISession session)
+        public PermissionManager(ISession session, UrbanDbContext context)
         {
             _session = session;
+            _context = context;
         }
         public async Task<PermissionDTO> CreateNewPermission(CreateNewPermissionDTO input)
         {
@@ -43,6 +50,35 @@ namespace UrbanSpork.DataAccess
             {
                 permAgg.DisablePermission();
                 await _session.Commit();
+
+                /*
+                 * Explicitly revoke for each user that has requested, been granted, or been denied a permission
+                 * when the permission has been disabled, should take caution when allowing a permission to be disabled
+                 */
+                //get list of entities that have this permission
+                var userList = _context.UserDetailProjection.Where(a =>
+                    JsonConvert.DeserializeObject<Dictionary<Guid, PermissionDetails>>(a.PermissionList)
+                        .ContainsKey(id));
+                if (userList.Any())
+                {
+                    foreach (var user in userList)
+                    {
+                        //get the aggregates for those entities
+                        var userAgg = await _session.Get<UserAggregate>(user.UserId);
+                        //revoke the permission through each aggregate, using a new dto
+                        userAgg.RevokePermission(new RevokeUserPermissionDTO
+                        {
+                            ForId = userAgg.Id,
+                            ById = Guid.Empty,
+                            PermissionsToRevoke = new Dictionary<Guid, PermissionDetails>
+                            {
+                                { id, new PermissionDetails { Reason = "Permission was Disabled." } }
+                            }
+                        });
+                        await _session.Commit();
+                    }
+                }
+
             }
             return Mapper.Map<PermissionDTO>(permAgg);
         }

--- a/UrbanSpork.DataAccess/Projections/UserDetailProjection.cs
+++ b/UrbanSpork.DataAccess/Projections/UserDetailProjection.cs
@@ -116,27 +116,6 @@ namespace UrbanSpork.DataAccess.Projections
 
                     _context.UserDetailProjection.Update(user);
                     break;
-                case PermissionDiabledEvent pd:
-                    //when a premission is disabled, we want to get all users with that permission remove any status of request they might have had.
-                    var list = _context.UserDetailProjection.Where(a =>
-                        JsonConvert.DeserializeObject<Dictionary<Guid, PermissionDetails>>(a.PermissionList).ContainsKey(pd.Id));
-                        
-                    if (list.Any())
-                    {
-                        foreach (var u in list)
-                        {
-                            _context.UserDetailProjection.Attach(u);
-
-                            permissionList =
-                                JsonConvert.DeserializeObject<Dictionary<Guid, PermissionDetails>>(u.PermissionList);
-                            permissionList.Remove(pd.Id);
-                            u.PermissionList = JsonConvert.SerializeObject(permissionList);
-
-                            _context.Entry(u).Property(a => a.PermissionList).IsModified = true;
-                            _context.UserDetailProjection.Update(u);
-                        }
-                    }
-                    break;
                 case UserPermissionRequestDeniedEvent pde:
                     if (pde.PermissionsToDeny.Any())
                     {


### PR DESCRIPTION
When a permission is disabled all users with that permission have it explicitly revoked now instead of it deleting it from projections.