### PR TITLE
Added logic to RevokePermissions

### DIFF
--- a/api/UrbanSpork.DataAccess/Events/Users/UserPermissionRevokedEvent.cs
+++ b/api/UrbanSpork.DataAccess/Events/Users/UserPermissionRevokedEvent.cs
@@ -32,7 +32,7 @@ namespace UrbanSpork.DataAccess.Events.Users
                 {
                     EventType = JsonConvert.SerializeObject(GetType().FullName),
                     IsPending = false,
-                    Reason = reason, //IDK?
+                    Reason = reason, 
                     RequestDate = TimeStamp,
                     RequestedBy = dto.ById,
                     RequestedFor = dto.ForId

--- a/api/UrbanSpork.DataAccess/PermissionManager.cs
+++ b/api/UrbanSpork.DataAccess/PermissionManager.cs
@@ -66,10 +66,11 @@ namespace UrbanSpork.DataAccess
                         //get the aggregates for those entities
                         var userAgg = await _session.Get<UserAggregate>(user.UserId);
                         //revoke the permission through each aggregate, using a new dto
-                        userAgg.RevokePermission(new RevokeUserPermissionDTO
+                        //this will circumvent the usermanager and each aggregate will revoke its own access
+                        userAgg.RevokePermission(userAgg, new RevokeUserPermissionDTO
                         {
                             ForId = userAgg.Id,
-                            ById = Guid.Empty,
+                            ById = userAgg.Id,
                             PermissionsToRevoke = new Dictionary<Guid, PermissionDetails>
                             {
                                 { id, new PermissionDetails { Reason = "Permission was Disabled." } }

--- a/api/UrbanSpork.DataAccess/UserAggregate.cs
+++ b/api/UrbanSpork.DataAccess/UserAggregate.cs
@@ -80,10 +80,13 @@ namespace UrbanSpork.DataAccess
             ApplyChange(new UserPermissionGrantedEvent(dto));
         }
 
-        public void RevokePermission(RevokeUserPermissionDTO dto)
+        public void RevokePermission(UserAggregate byAgg, RevokeUserPermissionDTO dto)
         {
-            //business Logic here!
-            ApplyChange(new UserPermissionRevokedEvent(dto));
+            //Users are allowed to revoke their own permissions, this is because permissionDisabledEvent requires it.
+            if (byAgg.IsAdmin || this == byAgg)
+            {
+                ApplyChange(new UserPermissionRevokedEvent(dto));
+            }
         }
 
         private void Apply(UserCreatedEvent @event)
@@ -123,7 +126,7 @@ namespace UrbanSpork.DataAccess
         {
             foreach (var request in @event.Requests)
             {
-                PermissionList[request.Key] = request.Value; //add if not there, update if it is. Losing the DateCreated for some reason.
+                PermissionList[request.Key] = request.Value; 
             }
         }
 


### PR DESCRIPTION
Users may not revoke their own permissions explicitly. PermissionManager is allowed to tell aggregates to revoke their own permissions. Only users that have granted permissions may have them revoked, only admins can revoke.