### PR TITLE
US-074/075

### DIFF
--- a/api/UrbanSpork.Common/FilterCriteria/SystemReportFilterCriteria.cs
+++ b/api/UrbanSpork.Common/FilterCriteria/SystemReportFilterCriteria.cs
@@ -6,6 +6,8 @@ namespace UrbanSpork.Common.FilterCriteria
 {
     public class SystemReportFilterCriteria
     {
+        public Guid PermissionId { get; set; } = Guid.Empty;
+
         public string SearchTerms { get; set; } = "";
 
         public string SortDirection { get; set; } = "ASC";

--- a/api/UrbanSpork.DataAccess/Projections/SystemActivityProjection.cs
+++ b/api/UrbanSpork.DataAccess/Projections/SystemActivityProjection.cs
@@ -47,39 +47,46 @@ namespace UrbanSpork.DataAccess.Projections
                 case UserPermissionGrantedEvent pg:
                     foreach (var permission in pg.PermissionsToGrant)
                     {
-                        proj.ForId = pg.ForId;
-                        proj.ById = pg.ById;
-                        proj.PermissionId = permission.Key;
-                        proj.EventType = "Permission Granted";
-                        proj.Timestamp = pg.TimeStamp;
-                        proj.PermissionName = await _context.PermissionDetailProjection.Where(a => a.PermissionId == permission.Key).Select(p => p.Name).SingleOrDefaultAsync();
-                        proj.ForFullName = await _context.UserDetailProjection.Where(a => a.UserId == pg.ForId).Select(p => p.FirstName + " " + p.LastName).SingleOrDefaultAsync();
-                        proj.ByFullName = await _context.UserDetailProjection.Where(a => a.UserId == pg.ById).Select(p => p.FirstName + " " + p.LastName).SingleOrDefaultAsync();
+                        //US-075
+                        var newGrantedRow = new SystemActivityProjection
+                        {
+                            ForId = pg.ForId,
+                            ById = pg.ById,
+                            PermissionId = permission.Key,
+                            EventType = "Permission Granted",
+                            Timestamp = pg.TimeStamp,
+                            PermissionName = await _context.PermissionDetailProjection.Where(a => a.PermissionId == permission.Key).Select(p => p.Name).SingleOrDefaultAsync(),
+                            ForFullName = await _context.UserDetailProjection.Where(a => a.UserId == pg.ForId).Select(p => p.FirstName + " " + p.LastName).SingleOrDefaultAsync(),
+                            ByFullName = await _context.UserDetailProjection.Where(a => a.UserId == pg.ById).Select(p => p.FirstName + " " + p.LastName).SingleOrDefaultAsync()
+                        };
 
-                        await _context.SystemActivityProjection.AddAsync(proj);
+                        _context.SystemActivityProjection.Add(newGrantedRow);
                     }
                     break;
 
                 case UserPermissionRevokedEvent pr:
                     foreach (var permission in pr.PermissionsToRevoke)
                     {
-                        proj.ForId = pr.ForId;
-                        proj.ById = pr.ById;
-                        proj.PermissionId = permission.Key;
-                        proj.EventType = "Permission Revoked";
-                        proj.Timestamp = pr.TimeStamp;
-                        proj.PermissionName = await _context.PermissionDetailProjection.Where(a => a.PermissionId == permission.Key).Select(p => p.Name).SingleOrDefaultAsync();
-                        proj.ForFullName = await _context.UserDetailProjection.Where(a => a.UserId == pr.ForId).Select(p => p.FirstName + " " + p.LastName).SingleOrDefaultAsync();
+                        var newRevokedRow = new SystemActivityProjection
+                        {
+                            ForId = pr.ForId,
+                            ById = pr.ById,
+                            PermissionId = permission.Key,
+                            EventType = "Permission Revoked",
+                            Timestamp = pr.TimeStamp,
+                            PermissionName = await _context.PermissionDetailProjection.Where(a => a.PermissionId == permission.Key).Select(p => p.Name).SingleOrDefaultAsync(),
+                            ForFullName = await _context.UserDetailProjection.Where(a => a.UserId == pr.ForId).Select(p => p.FirstName + " " + p.LastName).SingleOrDefaultAsync()
+                        };
                         if (pr.ById != Guid.Empty)
                         {
-                            proj.ByFullName = await _context.UserDetailProjection.Where(a => a.UserId == pr.ById).Select(p => p.FirstName + " " + p.LastName).SingleOrDefaultAsync();
+                            newRevokedRow.ByFullName = await _context.UserDetailProjection.Where(a => a.UserId == pr.ById).Select(p => p.FirstName + " " + p.LastName).SingleOrDefaultAsync();
                         }
                         else
                         {
-                            proj.ByFullName = "System";
+                            newRevokedRow.ByFullName = "System";
                         }
 
-                        await _context.SystemActivityProjection.AddAsync(proj);
+                        await _context.SystemActivityProjection.AddAsync(newRevokedRow);
                     }
                     break;
 

--- a/api/UrbanSpork.ReadModel/QueryHandlers/GetSystemReportQueryHandler.cs
+++ b/api/UrbanSpork.ReadModel/QueryHandlers/GetSystemReportQueryHandler.cs
@@ -58,9 +58,14 @@ namespace UrbanSpork.ReadModel.QueryHandlers
                 query = query.OrderByDescending(a => a.ForFullName);
             }
 
+            if (criteria.PermissionId != Guid.Empty)
+            {
+                query = query.Where(a => a.PermissionId == criteria.PermissionId);
+            }
+
             //return all actions within a range that are less than the given date, default date is time of query
             //when querying, enter a local time, this will take care of conversion from utc to local
-            query = query.Where(a => a.Timestamp.ToLocalTime() <= criteria.EndDate);
+            query = query.Where(a => a.Timestamp <= criteria.EndDate);
             
             var list = await query.ToListAsync();
 


### PR DESCRIPTION
Added a permissionId to systemReportFiterCriteria to filter by a specific system. Fixed bug in SystemActivityProjection where when multiple permissions were being granted, it would only get the last one because it was copying over the same variable.